### PR TITLE
Allow shopperToken generation with shopperId: ''

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lightrail-client",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A Javascript and Typescript client for Lightrail",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -149,6 +149,28 @@ describe("index", () => {
             chai.assert.equal(payload.exp, payload.iat + 600);
         });
 
+        it("signs an empty shopperId", () => {
+            index.configure({
+                apiKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnIjp7Imd1aSI6Imdvb2V5IiwiZ21pIjoiZ2VybWllIn19.XxOjDsluAw5_hdf5scrLk0UBn8VlhT-3zf5ZeIkEld8",
+                sharedSecret: "secret"
+            });
+
+            const shopperToken = index.generateShopperToken({shopperId: ""}, 600);
+            chai.assert.isString(shopperToken);
+
+            const payload = jsonwebtoken.verify(shopperToken, "secret") as any;
+            chai.assert.isObject(payload);
+            chai.assert.deepEqual(payload.g, {
+                gui: "gooey",
+                gmi: "germie",
+                shi: ""
+            });
+            chai.assert.equal(payload.iss, "MERCHANT");
+            chai.assert.isNumber(payload.iat);
+            chai.assert.isNumber(payload.exp);
+            chai.assert.equal(payload.exp, payload.iat + 600);
+        });
+
         it("signs a shopper token with additional IDs", () => {
             index.configure({
                 apiKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnIjp7Imd1aSI6Imdvb2V5IiwiZ21pIjoiZ2VybWllIn19.XxOjDsluAw5_hdf5scrLk0UBn8VlhT-3zf5ZeIkEld8",

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,7 @@ export function generateShopperToken(contact: model.ContactIdentifier, options?:
     if (!contact) {
         throw new Error("contact not set");
     }
-    if (!contact.contactId && !contact.userSuppliedId && !contact.shopperId) {
+    if (!contact.contactId && !contact.userSuppliedId && contact.shopperId == null) {
         throw new Error("one of contact.contactId, contact.userSuppliedId or contact.shopperId must be set");
     }
 


### PR DESCRIPTION
Fixes a bug that prevented unauthenticated shopper tokens from being generated with an empty string in place of a shopperId.