### PR TITLE
name is a required program param

### DIFF
--- a/src/params/programs/CreateProgramParams.ts
+++ b/src/params/programs/CreateProgramParams.ts
@@ -6,7 +6,7 @@ import {RedemptionRule} from "../../model/RedemptionRule";
 export interface CreateProgramParams {
     id: string;
     currency: string;
-    name?: string;
+    name: string;
     discount?: boolean;
     discountSellerLiability?: number;
     pretax?: boolean;


### PR DESCRIPTION
In working on Program create I noticed that `CreateProgramParams` had `name` as optional