### PR TITLE
New endpoints for generic code along with missing value transactions list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "lightrail-client",
-  "version": "3.2.0",
+  "version": "3.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16,7 +16,7 @@
       "integrity": "sha512-MFiW54UOSt+f2bRw8J7LgQeIvE/9b4oGvwU7XW30S9QGAiHGnU/fmiOprsyMkdmH2rl8xSPc0/yrQw8juXU6bQ==",
       "dev": true,
       "requires": {
-        "@types/chai": "*"
+        "@types/chai": "4.1.7"
       }
     },
     "@types/cookiejar": {
@@ -31,7 +31,7 @@
       "integrity": "sha512-gmbNb7V1LbJQA4MmH0hVFgqY1cyKsa6RvKC1Xrq0WBnZ0JuuvXKciXx/s8dN0LVXCJd8xO6wIaSFSyUIoGph9g==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.12.17"
       }
     },
     "@types/dotenv-safe": {
@@ -40,7 +40,7 @@
       "integrity": "sha512-dKenQFun1QvLgICGddJB6pNKMnedZasHKkc9eU72UPFgTpy9HMGZOhmQiUyLIs426xc6rlEYORU0li3OBD7h3g==",
       "dev": true,
       "requires": {
-        "@types/dotenv": "*"
+        "@types/dotenv": "6.1.0"
       }
     },
     "@types/jsonwebtoken": {
@@ -49,7 +49,7 @@
       "integrity": "sha512-YKnUTR4VxwljbPORPrRon9E3uel1aD8nUdvzqArCCdMTWPvo0gnI2UZkwIHN2QATdj6HYXV/Iq3/KcecAO42Ww==",
       "dev": true,
       "requires": {
-        "@types/node": "*"
+        "@types/node": "10.12.17"
       }
     },
     "@types/mocha": {
@@ -75,8 +75,8 @@
       "integrity": "sha512-h7dQyzEGQFY3Ya8pIu0fxcWaMWC2DDSKR78gHrh6GVnXUqXo/+93wd4RObXA13rKp4ETyym3yq2A0AxROx9AxQ==",
       "dev": true,
       "requires": {
-        "@types/cookiejar": "*",
-        "@types/node": "*"
+        "@types/cookiejar": "2.1.0",
+        "@types/node": "10.12.17"
       }
     },
     "ansi-regex": {
@@ -95,7 +95,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "~1.0.2"
+        "sprintf-js": "1.0.3"
       }
     },
     "arrify": {
@@ -121,9 +121,9 @@
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
       "dev": true,
       "requires": {
-        "chalk": "^1.1.3",
-        "esutils": "^2.0.2",
-        "js-tokens": "^3.0.2"
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.2"
       }
     },
     "balanced-match": {
@@ -138,7 +138,7 @@
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
       "dev": true,
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -171,12 +171,12 @@
       "integrity": "sha512-XQU3bhBukrOsQCuwZndwGcCVQHyZi53fQ6Ys1Fym7E4olpIqqZZhhoFJoaKVvV17lWQoXYwgWN2nF5crA8J2jw==",
       "dev": true,
       "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "pathval": "^1.1.0",
-        "type-detect": "^4.0.5"
+        "assertion-error": "1.1.0",
+        "check-error": "1.0.2",
+        "deep-eql": "3.0.1",
+        "get-func-name": "2.0.0",
+        "pathval": "1.1.0",
+        "type-detect": "4.0.8"
       }
     },
     "chai-as-promised": {
@@ -185,7 +185,7 @@
       "integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
       "dev": true,
       "requires": {
-        "check-error": "^1.0.2"
+        "check-error": "1.0.2"
       }
     },
     "chai-exclude": {
@@ -194,7 +194,7 @@
       "integrity": "sha512-7xJgaLhigf51U+s7k23vOLnXk4w/rIffmlnUu/ueYJg21sLyrTqCn3BxvOjbGNGYgXTQNFwjFX3lUnbcai0oCA==",
       "dev": true,
       "requires": {
-        "fclone": "^1.0.11"
+        "fclone": "1.0.11"
       }
     },
     "chalk": {
@@ -202,11 +202,11 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
       "requires": {
-        "ansi-styles": "^2.2.1",
-        "escape-string-regexp": "^1.0.2",
-        "has-ansi": "^2.0.0",
-        "strip-ansi": "^3.0.0",
-        "supports-color": "^2.0.0"
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
       }
     },
     "check-error": {
@@ -235,7 +235,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -279,7 +279,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "^4.0.0"
+        "type-detect": "4.0.8"
       }
     },
     "delayed-stream": {
@@ -305,7 +305,7 @@
       "integrity": "sha512-O02OUTS+XmoRNZR4kRjJ9jlUGvQoXpMeTVVEBc8hUtgvPTgVZpsZH7TOocq4RVDpPrs2xGPwj6gIWjqRX+ErHA==",
       "dev": true,
       "requires": {
-        "dotenv": "^6.1.0"
+        "dotenv": "6.2.0"
       }
     },
     "ecdsa-sig-formatter": {
@@ -313,7 +313,7 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.10.tgz",
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "escape-string-regexp": {
@@ -349,9 +349,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
       "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
       "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.5",
-        "mime-types": "^2.1.12"
+        "asynckit": "0.4.0",
+        "combined-stream": "1.0.5",
+        "mime-types": "2.1.17"
       }
     },
     "formidable": {
@@ -377,12 +377,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "fs.realpath": "1.0.0",
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "growl": {
@@ -396,7 +396,7 @@
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "has-flag": {
@@ -417,8 +417,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -443,8 +443,8 @@
       "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
       "dev": true,
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "1.0.10",
+        "esprima": "4.0.1"
       }
     },
     "jsonwebtoken": {
@@ -452,15 +452,15 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.4.0.tgz",
       "integrity": "sha512-coyXjRTCy0pw5WYBpMvWOMN+Kjaik2MwTUIq9cna/W7NpO9E+iYbumZONAz3hcr+tXFJECoQVrtmIoC3Oz0gvg==",
       "requires": {
-        "jws": "^3.1.5",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1"
+        "jws": "3.1.5",
+        "lodash.includes": "4.3.0",
+        "lodash.isboolean": "3.0.3",
+        "lodash.isinteger": "4.0.4",
+        "lodash.isnumber": "3.0.3",
+        "lodash.isplainobject": "4.0.6",
+        "lodash.isstring": "4.0.1",
+        "lodash.once": "4.1.1",
+        "ms": "2.1.1"
       },
       "dependencies": {
         "ms": {
@@ -477,7 +477,7 @@
       "requires": {
         "buffer-equal-constant-time": "1.0.1",
         "ecdsa-sig-formatter": "1.0.10",
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.1"
       }
     },
     "jws": {
@@ -485,8 +485,8 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
       "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
       "requires": {
-        "jwa": "^1.1.5",
-        "safe-buffer": "^5.0.1"
+        "jwa": "1.1.6",
+        "safe-buffer": "5.1.1"
       }
     },
     "lodash.includes": {
@@ -550,7 +550,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "~1.30.0"
+        "mime-db": "1.30.0"
       }
     },
     "minimatch": {
@@ -559,7 +559,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.8"
       }
     },
     "minimist": {
@@ -574,8 +574,8 @@
       "integrity": "sha512-XVo3zTSYjZp/JI2TnURBDNHcFCi5GGLGMeBqgBrwShQgIZnp0WIn3AjCE8fE60iLeNWIhgDHqzyDhXkZ0z86qQ==",
       "dev": true,
       "requires": {
-        "semver": ">= 5 < 6",
-        "underscore": ">= 1.1.6 < 1.6"
+        "semver": "5.4.1",
+        "underscore": "1.5.2"
       }
     },
     "mkdirp": {
@@ -612,7 +612,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -628,7 +628,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "parse-link-header": {
@@ -636,7 +636,7 @@
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
       "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
       "requires": {
-        "xtend": "~4.0.1"
+        "xtend": "4.0.1"
       }
     },
     "path-is-absolute": {
@@ -672,13 +672,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~1.0.6",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.0.3",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.1.1",
+        "string_decoder": "1.0.3",
+        "util-deprecate": "1.0.2"
       }
     },
     "resolve": {
@@ -687,7 +687,7 @@
       "integrity": "sha512-TZNye00tI67lwYvzxCxHGjwTNlUV70io54/Ed4j6PscB8xVfuBJpRenI/o6dVk0cY0PYTY27AgCoGGxRnYuItQ==",
       "dev": true,
       "requires": {
-        "path-parse": "^1.0.6"
+        "path-parse": "1.0.6"
       }
     },
     "rimraf": {
@@ -696,7 +696,7 @@
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "dev": true,
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       }
     },
     "safe-buffer": {
@@ -722,8 +722,8 @@
       "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
       "dev": true,
       "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
+        "buffer-from": "1.1.1",
+        "source-map": "0.6.1"
       }
     },
     "sprintf-js": {
@@ -737,7 +737,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.1"
       }
     },
     "strip-ansi": {
@@ -745,7 +745,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "superagent": {
@@ -753,16 +753,16 @@
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.1.tgz",
       "integrity": "sha512-VMBFLYgFuRdfeNQSMLbxGSLfmXL/xc+OO+BZp41Za/NRDBet/BNbkRJrYzCUu0u4GU0i/ml2dtT8b9qgkw9z6Q==",
       "requires": {
-        "component-emitter": "^1.2.0",
-        "cookiejar": "^2.1.0",
-        "debug": "^3.1.0",
-        "extend": "^3.0.0",
-        "form-data": "^2.3.1",
-        "formidable": "^1.1.1",
-        "methods": "^1.1.1",
-        "mime": "^1.4.1",
-        "qs": "^6.5.1",
-        "readable-stream": "^2.0.5"
+        "component-emitter": "1.2.1",
+        "cookiejar": "2.1.1",
+        "debug": "3.1.0",
+        "extend": "3.0.1",
+        "form-data": "2.3.1",
+        "formidable": "1.1.1",
+        "methods": "1.1.2",
+        "mime": "1.4.1",
+        "qs": "6.5.1",
+        "readable-stream": "2.3.3"
       }
     },
     "superagent-logger": {
@@ -771,7 +771,7 @@
       "integrity": "sha1-/J6c/hYXOWBLiYoeuXHstlo9VM8=",
       "optional": true,
       "requires": {
-        "chalk": "^1.1.0"
+        "chalk": "1.1.3"
       }
     },
     "supports-color": {
@@ -785,14 +785,14 @@
       "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
       "dev": true,
       "requires": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
+        "arrify": "1.0.1",
+        "buffer-from": "1.1.1",
+        "diff": "3.5.0",
+        "make-error": "1.3.5",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "source-map-support": "0.5.9",
+        "yn": "2.0.0"
       },
       "dependencies": {
         "minimist": {
@@ -815,18 +815,18 @@
       "integrity": "sha512-CKEcH1MHUBhoV43SA/Jmy1l24HJJgI0eyLbBNSRyFlsQvb9v6Zdq+Nz2vEOH00nC5SUx4SneJ59PZUS/ARcokQ==",
       "dev": true,
       "requires": {
-        "babel-code-frame": "^6.22.0",
-        "builtin-modules": "^1.1.1",
-        "chalk": "^2.3.0",
-        "commander": "^2.12.1",
-        "diff": "^3.2.0",
-        "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
-        "minimatch": "^3.0.4",
-        "resolve": "^1.3.2",
-        "semver": "^5.3.0",
-        "tslib": "^1.8.0",
-        "tsutils": "^2.27.2"
+        "babel-code-frame": "6.26.0",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.4.1",
+        "commander": "2.15.1",
+        "diff": "3.5.0",
+        "glob": "7.1.2",
+        "js-yaml": "3.12.0",
+        "minimatch": "3.0.4",
+        "resolve": "1.9.0",
+        "semver": "5.4.1",
+        "tslib": "1.9.3",
+        "tsutils": "2.29.0"
       },
       "dependencies": {
         "ansi-styles": {
@@ -835,7 +835,7 @@
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "dev": true,
           "requires": {
-            "color-convert": "^1.9.0"
+            "color-convert": "1.9.3"
           }
         },
         "chalk": {
@@ -844,9 +844,9 @@
           "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
+            "ansi-styles": "3.2.1",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "5.5.0"
           }
         },
         "supports-color": {
@@ -855,7 +855,7 @@
           "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "3.0.0"
           }
         }
       }
@@ -866,7 +866,7 @@
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
       "dev": true,
       "requires": {
-        "tslib": "^1.8.1"
+        "tslib": "1.9.3"
       }
     },
     "type-detect": {

--- a/src/contacts.test.ts
+++ b/src/contacts.test.ts
@@ -139,6 +139,31 @@ describe("contacts", () => {
             chai.assert.notEqual(value.body.contactId, attachedValue.body.contactId);
             chai.assert.equal(attachedValue.body.contactId, attachToContactID);
         });
+
+        it("attaches a generic Value as a new Value to the Contact", async () => {
+            // Create Value
+            const valueID = uuid.v4().substring(0, 20);
+            const value = await Lightrail.values.createValue({
+                id: valueID,
+                currency: "USD",
+                balance: 33,
+                isGenericCode: true
+            });
+
+            // Create Contact and Attach Value
+            let contact = await Lightrail.contacts.getContact(attachToContactID);
+            if (!contact.body) {
+                await Lightrail.contacts.createContact({
+                    ...testContact,
+                    id: attachToContactID,
+                    email: "testAttach@fake.com"
+                });
+            }
+            const attachedValue = await Lightrail.contacts.attachContactToValue(attachToContactID, {valueId: valueID, attachGenericAsNewValue: true});
+            chai.assert.equal(attachedValue.status, 200);
+            chai.assert.notEqual(value.body.id, attachedValue.body.id);
+            chai.assert.equal(contact.body.id, attachedValue.body.contactId);
+        });
     });
 
     describe("listContactValues(id, params)", () => {

--- a/src/params/ContentTypeParams.ts
+++ b/src/params/ContentTypeParams.ts
@@ -1,0 +1,3 @@
+export interface ContentTypeParams {
+    csv?: boolean;
+}

--- a/src/params/contacts/AttachContactToValueParams.ts
+++ b/src/params/contacts/AttachContactToValueParams.ts
@@ -4,6 +4,7 @@ import {Value} from "../../model";
 export interface AttachContactToValueParams {
     valueId?: string;
     code?: string;
+    attachGenericAsNewValue?: boolean;
 }
 
 export interface AttachContactToValueResponse extends LightrailResponse<Value> {

--- a/src/params/contacts/ListContactsParams.ts
+++ b/src/params/contacts/ListContactsParams.ts
@@ -2,13 +2,15 @@ import {Contact} from "../../model";
 import {FilterableString} from "../FilterableParams";
 import {PaginatedLightrailResponse} from "../LightrailResponse";
 import {PaginationParams} from "../PaginationParams";
+import {ContentTypeParams} from "../ContentTypeParams";
 
-export interface ListContactsParams extends PaginationParams {
+export interface ListContactsParams extends PaginationParams, ContentTypeParams {
     id?: FilterableString;
     tags?: FilterableString;
     firstName?: FilterableString;
     lastName?: FilterableString;
     email?: FilterableString;
+    valueId?: FilterableString;
 }
 
 export interface ListContactsResponse extends PaginatedLightrailResponse<Array<Contact>> {

--- a/src/params/currencies/ListCurrenciesParams.ts
+++ b/src/params/currencies/ListCurrenciesParams.ts
@@ -1,8 +1,9 @@
 import {LightrailResponse} from "../LightrailResponse";
 import {Currency} from "../../model/Currency";
 import {PaginationParams} from "../PaginationParams";
+import {ContentTypeParams} from "../ContentTypeParams";
 
-export interface ListCurrenciesParams extends PaginationParams {
+export interface ListCurrenciesParams extends PaginationParams, ContentTypeParams {
 }
 
 export interface ListCurreniesResponse extends LightrailResponse<Currency[]> {

--- a/src/params/programs/issuance/ListIssuancesParams.ts
+++ b/src/params/programs/issuance/ListIssuancesParams.ts
@@ -1,8 +1,9 @@
 import {PaginatedLightrailResponse} from "../../LightrailResponse";
 import {Issuance} from "../../../model/Issuance";
 import {PaginationParams} from "../../PaginationParams";
+import {ContentTypeParams} from "../../ContentTypeParams";
 
-export interface ListIssuancesParams extends PaginationParams {
+export interface ListIssuancesParams extends PaginationParams, ContentTypeParams {
 }
 
 export interface ListIssuancesResponse extends PaginatedLightrailResponse<Issuance[]> {

--- a/src/params/transactions/ListTransactionsParams.ts
+++ b/src/params/transactions/ListTransactionsParams.ts
@@ -2,6 +2,7 @@ import {PaginationParams} from "../PaginationParams";
 import {PaginatedLightrailResponse} from "../LightrailResponse";
 import {Transaction} from "../../model";
 import {FilterableString} from "../FilterableParams";
+import {ContentTypeParams} from "../ContentTypeParams";
 
 export interface ListTransactionsParams extends PaginationParams {
     transactionType?: FilterableString;

--- a/src/params/values/ListValuesParams.ts
+++ b/src/params/values/ListValuesParams.ts
@@ -2,10 +2,10 @@ import {PaginatedLightrailResponse} from "../LightrailResponse";
 import {Value} from "../../model/Value";
 import {FilterableNumber, FilterableString} from "../FilterableParams";
 import {PaginationParams} from "../PaginationParams";
+import {ContentTypeParams} from "../ContentTypeParams";
 
-export interface ListValuesParams extends PaginationParams {
+export interface ListValuesParams extends PaginationParams, ContentTypeParams {
     formatCurrencies?: boolean;
-    csv?: boolean;
     issuanceId?: string;
     showCode?: boolean;
     programId?: FilterableString;

--- a/src/programs.test.ts
+++ b/src/programs.test.ts
@@ -24,7 +24,7 @@ describe("programs", () => {
                 name: "javascript programs unit test",
                 currency: "USD",
                 discount: false,
-                discountSellerLiability: 0,
+                discountSellerLiability: null,
                 pretax: false,
                 active: true,
                 redemptionRule: {

--- a/src/values.test.ts
+++ b/src/values.test.ts
@@ -1,13 +1,13 @@
 import * as chai from "chai";
 import * as Lightrail from "./index";
 import * as uuid from "uuid";
-import {CreateValueParams} from "./params";
+import {CreateContactParams, CreateValueParams} from "./params";
 import chaiExclude = require("chai-exclude");
 
 chai.use(chaiExclude);
 
 describe("values", () => {
-    before(() => {
+    before(async () => {
         Lightrail.configure({
             restRoot: process.env.LIGHTRAIL_API_PATH || "",
             apiKey: process.env.LIGHTRAIL_API_KEY || "",
@@ -176,5 +176,43 @@ describe("values", () => {
             chai.assert.isNotNull(response.body);
             chai.assert.isTrue(response.body.success);
         });
+    });
+
+
+    it("listValuesTransactions(value)", async () => {
+        const valueParams: CreateValueParams = {
+            id: uuid.v4().substring(0, 12),
+            currency: "USD",
+            balance: 500,
+        };
+        const value = await Lightrail.values.createValue(valueParams);
+        chai.assert.equal(value.status, 201);
+
+        const getValuesAttachedContacts = await Lightrail.values.listValuesTransactions(valueParams.id);
+        chai.assert.equal(getValuesAttachedContacts.status, 200);
+        chai.assert.equal(getValuesAttachedContacts.body.length, 1);
+        chai.assert.equal(getValuesAttachedContacts.body[0].transactionType, "initialBalance");
+    });
+
+    it("listValuesAttachedContacts(value)", async () => {
+        const testContact: CreateContactParams = {
+            id: uuid.v4().substring(0, 24),
+            email: "test@example.com"
+        };
+        const contact = await Lightrail.contacts.createContact(testContact);
+        chai.assert.equal(contact.status, 201);
+
+        const valueParams: CreateValueParams = {
+            id: uuid.v4().substring(0, 24),
+            currency: "USD",
+            contactId: testContact.id,
+            balance: 500,
+        };
+        const value = await Lightrail.values.createValue(valueParams);
+        chai.assert.equal(contact.status, 201);
+
+        const getValuesAttachedContacts = await Lightrail.values.listValuesAttachedContacts(value.body);
+        chai.assert.equal(getValuesAttachedContacts.status, 200);
+        chai.assert.deepEqual(getValuesAttachedContacts.body, [contact.body]);
     });
 });

--- a/src/values.ts
+++ b/src/values.ts
@@ -5,7 +5,7 @@ import {
     CreateValueResponse,
     DeleteValueResponse,
     GetValueParams,
-    GetValueResponse,
+    GetValueResponse, ListContactsParams, ListContactsResponse, ListTransactionsParams, ListTransactionsResponse,
     ListValuesParams,
     ListValuesResponse,
     UpdateValueParams,
@@ -92,6 +92,34 @@ export async function deleteValue(value: string | Value): Promise<DeleteValueRes
 
     const resp = await lightrail.request("DELETE", `values/${encodeURIComponent(valueId)}`);
     if (isSuccessStatus(resp.status) || resp.status === 404) {
+        return (
+            formatResponse(resp)
+        );
+    }
+
+    throw new LightrailRequestError(resp);
+}
+
+// LIST VALUES TRANSACTIONS
+export async function listValuesTransactions(value: string | Value, params?: ListTransactionsParams): Promise<ListTransactionsResponse> {
+    const valueId = getValueId(value);
+
+    const resp = await lightrail.request("GET", `values/${encodeURIComponent(valueId)}/transactions`).query(formatFilterParams(params));
+    if (isSuccessStatus(resp.status)) {
+        return (
+            formatResponse(resp)
+        );
+    }
+
+    throw new LightrailRequestError(resp);
+}
+
+// LIST VALUES ATTACHED CONTACTS
+export async function listValuesAttachedContacts(value: string | Value, params?: ListContactsParams): Promise<ListContactsResponse> {
+    const valueId = getValueId(value);
+
+    const resp = await lightrail.request("GET", `values/${encodeURIComponent(valueId)}/contacts`).set("accept", (!!params && !!params.csv) ? "text/csv" : "application/json").query(formatFilterParams(params));
+    if (isSuccessStatus(resp.status)) {
         return (
             formatResponse(resp)
         );


### PR DESCRIPTION
- added new generic code endpoints (/values/{id}/contacts
- set ContentTypeParams on all list endpoints that support csv (Transaction lists currently do not. This may be an oversight in the LR API.)
- added attachGenericAsNewValue parameter to attach params.